### PR TITLE
proto: enable UseCachedSize size option

### DIFF
--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -23,11 +23,10 @@ package proto
 import (
 	"fmt"
 
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/protoadapt"
-
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/mem"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/protoadapt"
 )
 
 // Name is the name registered for the proto compressor.

--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -23,10 +23,11 @@ package proto
 import (
 	"fmt"
 
-	"google.golang.org/grpc/encoding"
-	"google.golang.org/grpc/mem"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/protoadapt"
+
+	"google.golang.org/grpc/encoding"
+	"google.golang.org/grpc/mem"
 )
 
 // Name is the name registered for the proto compressor.
@@ -48,7 +49,7 @@ func (c *codecV2) Marshal(v any) (data mem.BufferSlice, err error) {
 
 	size := proto.Size(vv)
 	if mem.IsBelowBufferPoolingThreshold(size) {
-		buf, err := proto.Marshal(vv)
+		buf, err := proto.MarshalOptions{UseCachedSize: true}.Marshal(vv)
 		if err != nil {
 			return nil, err
 		}
@@ -56,7 +57,7 @@ func (c *codecV2) Marshal(v any) (data mem.BufferSlice, err error) {
 	} else {
 		pool := mem.DefaultBufferPool()
 		buf := pool.Get(size)
-		if _, err := (proto.MarshalOptions{}).MarshalAppend((*buf)[:0], vv); err != nil {
+		if _, err := (proto.MarshalOptions{UseCachedSize: true}).MarshalAppend((*buf)[:0], vv); err != nil {
 			pool.Put(buf)
 			return nil, err
 		}


### PR DESCRIPTION
Enable UseCachedSize in proto marshal to eliminate redundant size computation

The proto message size was previously being computed twice: once before marshalling and again during the marshalling call itself. In high-throughput workloads, this duplicated computation is expensive.

By enabling `UseCachedSize` on `MarshalOptions`, we reuse the size calculated immediately before marshalling, avoiding the second call to `proto.Size`.

In our application, the redundant size call accounted for ~12% of total CPU time. With this change, we eliminate that overhead while preserving correctness.

RELEASE NOTES:
- proto: Reducing `proto.Size` calls when marshalling.

---

<img width="920" height="632" alt="image" src="https://github.com/user-attachments/assets/2d4f8572-beb1-4875-92ba-7e4b1ad86c26" />

<img width="824" height="634" alt="image" src="https://github.com/user-attachments/assets/8ee8aa9f-7789-432a-b0ce-145fb6e75cfb" />
